### PR TITLE
Include unittests in checkpoint cell for language-translation

### DIFF
--- a/language-translation/dlnd_language_translation.ipynb
+++ b/language-translation/dlnd_language_translation.ipynb
@@ -179,6 +179,7 @@
     "\"\"\"\n",
     "import numpy as np\n",
     "import helper\n",
+    "import problem_unittests as tests\n",
     "\n",
     "(source_int_text, target_int_text), (source_vocab_to_int, target_vocab_to_int), _ = helper.load_preprocess()"
    ]


### PR DESCRIPTION
The checkpoint does not currently include unittests which creates a
scenario where the user would have to run the first cell before
progressing from the checkpoint.